### PR TITLE
Change csv_dump scipt to enable filtering within a timeframe.

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,4 +1,0 @@
-[DatabaseSection]
-database.dbname=
-database.user=
-database.password=

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,4 @@
+[DatabaseSection]
+database.dbname=postgres
+database.user=anju
+database.password=

--- a/config.ini
+++ b/config.ini
@@ -1,4 +1,4 @@
 [DatabaseSection]
-database.dbname=postgres
-database.user=anju
+database.dbname=
+database.user=
 database.password=

--- a/csv_dump.py
+++ b/csv_dump.py
@@ -13,7 +13,7 @@ def initialize_logging():
 
 def get_config(filepath='config.json', section='database'):
     """ Reads config file and retrieves configs from a given section
-    
+
     Args:
         filepath (str): Filepath of the config file.
         section (str): Secton of the config file to read
@@ -83,7 +83,7 @@ def check_directory(dir_path):
             else:
                 logging.info("File Path Exists: {}".format(dir_path))
 
-def query_and_write_data(cur, table_name, base_path):
+def query_and_write_data(cur, table_query_info, base_path, start_date, end_date):
     '''Queries all data and headers from a given table, and writes it to a csv file.
     Path of the file is as such: {base_path}{table_name}/{todays date}.csv
 
@@ -93,27 +93,60 @@ def query_and_write_data(cur, table_name, base_path):
         base_path (str): Base path of where the CSV file dump of the table is to be stored.
                         (Example: /example/path/to/desired/directory/)
     '''
-    query = "COPY (SELECT * FROM {}) TO STDOUT  DELIMITER ',' CSV HEADER;".format(table_name)
-    file_path = "{}{}/{}.csv".format(base_path, table_name, date.today().strftime("%Y_%m_%d"))
+    table_name, table_query, need_params, create_temp_table = table_query_info
+    if create_temp_table:
+        if need_params:
+            args = start_date, end_date
+            cur.execute(table_query, args)
+        else:
+            cur.execute(table_query)
+        # fetch from temp table
+        query = "select * from {}_temp".format(table_name)
+    else:
+        if need_params:
+            query = table_query.format(start_date, end_date)
+        else:
+            query = table_query
+    #file_path = "{}{}/{}.csv".format(base_path, table_name, date.today().strftime("%Y_%m_%d"))
+    file_path = "{}/{}.csv".format(base_path, start_date + "_" + end_date + "_" + table_name)
     check_directory(file_path)
     logging.info("Dumping {} table to {}".format(table_name, file_path))
-    with open(file_path, "w+") as file_to_write: #TODO: Should we write if the file already exists?
-        cur.copy_expert(query, file_to_write)
+    with open(file_path, "w+") as file_to_write:  # TODO: Should we write if the file already exists?
+        copy_query = "COPY ({}) TO STDOUT  DELIMITER ',' CSV HEADER;".format(query)
+        cur.copy_expert(copy_query, file_to_write)
         logging.info("{} table contents successfully written to {}\n".format(table_name, file_path))
-    
+
+
+def get_tables_and_query_mapping():
+    # Each element is of the format (table_name, sql_query, params_required, temp_table_created)
+    tables_and_query = []
+    tables_and_query.append(('item_ts', "select * from item_ts where start_ts >= '{}' and end_ts <= '{}'", True, False))
+    tables_and_query.append(('item', 'create temp table item_temp as (select * from item i where exists (select 1 from item_ts it where it.domain_id = i.domain_id and it.project_id = i.project_id and it.item_id = i.item_id and it.item_type_id = i.item_type_id and it.start_ts >= %s and it.end_ts <= %s))', True, True))
+    tables_and_query.append(('item_type', 'select * from item_type where item_type_id in (select item_type_id from item_temp)', False, False ))
+    tables_and_query.append(('catalog_item', 'select * from catalog_item where item_type_id in (select item_type_id from item_temp)', False, False))
+    tables_and_query.append(('project', 'create temp table project_temp as (select distinct p.* from project p inner join item_temp i on p.domain_id = i.domain_id and p.project_id = i.project_id)', False, True))
+    tables_and_query.append(('domain', 'select * from domain where domain_id in (select domain_id from project_temp)', False, False))
+    tables_and_query.append(('institution2project', 'create temp table institution2project_temp as (select * from institution2project i2p where exists (select 1 from project_temp p where p.project_id = i2p.project_id and p.domain_id = i2p.domain_id))', False, True))
+    tables_and_query.append(('institution', 'select * from institution where institution_id in (select institution_id from institution2project_temp)', False, False))
+    tables_and_query.append(('project2poc', 'create temp table project2poc_temp as (select distinct p2p.* from project2poc p2p inner join project_temp p on p2p.domain_id = p.domain_id and p2p.project_id = p.project_id)', False, True))
+    tables_and_query.append(('poc', 'select * from poc where poc_id in (select poc_id from project2poc_temp)', False, False))
+    tables_and_query.append(('address', 'select * from address where address_id in (select address_id from poc inner join project2poc_temp p on poc.poc_id = p.poc_id)', False, False))
+    return tables_and_query
 
 if __name__ == '__main__':
     # Initialize Logging
     initialize_logging()
     # Get DB Configs
-    config = get_config() 
+    config = get_config()
     # Establish Connection to Database
     conn = get_connection(config['host'], config['dbname'], config['user'], config['pass'])
     cur = conn.cursor()
     # Dump CSV files
+    start_date = '2019-01-30'
+    end_date = '2019-01-31'
     base_path = "{}/moc_reporting_csv_dump/".format(os.getcwd())
-    for table in get_tables(cur):
-        query_and_write_data(cur, table, base_path) 
+    for table_query_info in get_tables_and_query_mapping():
+        query_and_write_data(cur, table_query_info, base_path, start_date, end_date)
     # Close connection
     conn.close()
 

--- a/csv_dump.py
+++ b/csv_dump.py
@@ -128,10 +128,13 @@ if __name__ == '__main__':
 
     # check for args
     parser = argparse.ArgumentParser()
-    parser.add_argument("--active_timestamp", nargs='+', help="the timestamps where a VM was active", type=str)
+    parser.add_argument("--start_timestamp", help="the start timestamp where a VM was active",
+                        required=True)
+    parser.add_argument("--end_timestamp", help="the end timestamp till when a VM was active",
+                        required=True)
     args = parser.parse_args()
-    start_date = args.active_timestamp[0]
-    end_date = args.active_timestamp[1]
+    start_date = args.start_timestamp
+    end_date = args.end_timestamp
 
     # Initialize Logging
     initialize_logging()

--- a/csv_dump.py
+++ b/csv_dump.py
@@ -2,13 +2,10 @@ import psycopg2
 import os
 import errno
 import logging
-<<<<<<< HEAD
 import json
-=======
 import argparse
 import configparser
->>>>>>> add args for filtering
-from datetime import date
+from datetime import datetime
 
 def initialize_logging():
     '''Initializes Logging'''
@@ -113,7 +110,7 @@ def query_and_write_data(cur, table_query_info, base_path, start_date, end_date)
         else:
             query = table_query
     #file_path = "{}{}/{}.csv".format(base_path, table_name, date.today().strftime("%Y_%m_%d"))
-    file_path = "{}/{}/{}.csv".format(base_path, date.today().strftime("%Y_%m_%d"), start_date + "_" + end_date + "_" + table_name)
+    file_path = "{}/{}.csv".format(base_path, start_date + "_" + end_date + "_" + table_name)
     check_directory(file_path)
     logging.info("Dumping {} table to {}".format(table_name, file_path))
     with open(file_path, "w+") as file_to_write:  # TODO: Should we write if the file already exists?
@@ -139,8 +136,6 @@ def get_tables_and_query_mapping():
     return tables_and_query
 
 if __name__ == '__main__':
-<<<<<<< HEAD
-=======
 
     config = configparser.ConfigParser()
     config.read('config.ini')
@@ -154,7 +149,6 @@ if __name__ == '__main__':
     start_date = args.active_timestamp[0]
     end_date = args.active_timestamp[1]
 
->>>>>>> add args for filtering
     # Initialize Logging
     initialize_logging()
     # Get DB Configs
@@ -163,7 +157,7 @@ if __name__ == '__main__':
     conn = get_connection(config['host'], config['dbname'], config['user'], config['pass'])
     cur = conn.cursor()
     # Dump CSV files
-    base_path = "{}/moc_reporting_csv_dump/".format(os.getcwd())
+    base_path = "{}/moc_reporting_csv_dump/{}".format(os.getcwd(), datetime.now().strftime("%m_%d_%Y_%H:%M:%S"))
     for table_query_info in get_tables_and_query_mapping():
         query_and_write_data(cur, table_query_info, base_path, start_date, end_date)
     # Close connection

--- a/csv_dump.py
+++ b/csv_dump.py
@@ -125,10 +125,6 @@ def query_and_write_data(cur, table_query_info, base_path, start_date, end_date)
 
 
 if __name__ == '__main__':
-    config = configparser.ConfigParser()
-    config.read('config.ini')
-    db_name = config['DatabaseSection']['database.dbname']
-    user = config['DatabaseSection']['database.user']
 
     # check for args
     parser = argparse.ArgumentParser()

--- a/instructions.txt
+++ b/instructions.txt
@@ -1,0 +1,7 @@
+
+## Dumping csv files based on a timeframe:
+- Before testing establish connection to you local DB by changing db name and user name in config.ini file.
+- To get the csv dump run the following command:
+python3 csv_dump.py --active_timestamp [start_date] [end_date]
+eg: python3 csv_dump.py --active_timestamp 2019-01-30 2019-01-31
+- You should see the data dump in moc-reporting_csv_dump folder under the timestamp folder when it was run.

--- a/instructions.txt
+++ b/instructions.txt
@@ -1,7 +1,7 @@
 
 ## Dumping csv files based on a timeframe:
-- Before testing establish connection to you local DB by changing db name and user name in config.ini file.
+- Before testing establish connection to you local DB by changing db name, host name and user name in config.json file.
 - To get the csv dump run the following command:
-python3 csv_dump.py --active_timestamp [start_date] [end_date]
-eg: python3 csv_dump.py --active_timestamp 2019-01-30 2019-01-31
+python3 csv_dump.py --active_timestamp [start_date] --end_timestamp [end_date]
+eg: csv_dump.py --start_timestamp 2019-01-30 --end_timestamp 2019-01-31
 - You should see the data dump in moc-reporting_csv_dump folder under the timestamp folder when it was run.

--- a/instructions.txt
+++ b/instructions.txt
@@ -2,6 +2,6 @@
 ## Dumping csv files based on a timeframe:
 - Before testing establish connection to you local DB by changing db name, host name and user name in config.json file.
 - To get the csv dump run the following command:
-python3 csv_dump.py --active_timestamp [start_date] --end_timestamp [end_date]
+python3 csv_dump.py --start_timestamp [start_date] --end_timestamp [end_date]
 eg: csv_dump.py --start_timestamp 2019-01-30 --end_timestamp 2019-01-31
 - You should see the data dump in moc-reporting_csv_dump folder under the timestamp folder when it was run.

--- a/query_info.py
+++ b/query_info.py
@@ -1,0 +1,27 @@
+class QueryInfo:
+    def __init__(self, table_name, sql_query, params_required, create_temp_table):
+        self.table_name = table_name
+        self.sql_query = sql_query
+        self.params_required = params_required
+        self.create_temp_table = create_temp_table
+
+    @staticmethod
+    def get_query_infos_by_timeframe():
+        '''
+        Gets an array of queries to get the data from each table. Starts with the timestamp in item_ts table
+        :return: an array of queries for fetching data in each tables.
+        '''
+        # Each element is of the format (table_name, sql_query, params_required, temp_table_created)
+        query_infos = []
+        query_infos.append(QueryInfo('item_ts', "select * from item_ts where start_ts between '{}' and '{}'", True, False))
+        query_infos.append(QueryInfo('item', 'create temp table item_temp as (select * from item i where exists (select 1 from item_ts it where it.domain_id = i.domain_id and it.project_id = i.project_id and it.item_id = i.item_id and it.item_type_id = i.item_type_id and it.start_ts between %s and %s))', True, True))
+        query_infos.append(QueryInfo('item_type', 'select * from item_type where item_type_id in (select item_type_id from item_temp)', False, False ))
+        query_infos.append(QueryInfo('catalog_item', 'select * from catalog_item where item_type_id in (select item_type_id from item_temp)', False, False))
+        query_infos.append(QueryInfo('project', 'create temp table project_temp as (select distinct p.* from project p inner join item_temp i on p.domain_id = i.domain_id and p.project_id = i.project_id)', False, True))
+        query_infos.append(QueryInfo('domain', 'select * from domain where domain_id in (select domain_id from project_temp)', False, False))
+        query_infos.append(QueryInfo('institution2project', 'create temp table institution2project_temp as (select * from institution2project i2p where exists (select 1 from project_temp p where p.project_id = i2p.project_id and p.domain_id = i2p.domain_id))', False, True))
+        query_infos.append(QueryInfo('institution', 'select * from institution where institution_id in (select institution_id from institution2project_temp)', False, False))
+        query_infos.append(QueryInfo('project2poc', 'create temp table project2poc_temp as (select distinct p2p.* from project2poc p2p inner join project_temp p on p2p.domain_id = p.domain_id and p2p.project_id = p.project_id)', False, True))
+        query_infos.append(QueryInfo('poc', 'select * from poc where poc_id in (select poc_id from project2poc_temp)', False, False))
+        query_infos.append(QueryInfo('address', 'select * from address where address_id in (select address_id from poc inner join project2poc_temp p on poc.poc_id = p.poc_id)', False, False))
+        return query_infos


### PR DESCRIPTION
Description:
The PR enables data filtering of the db data with a start date and end date before dumping to csv files. The timestamp act as a timeframe where the VMs have been active. 

Testing PR:
- Before testing establish connection to you local DB by changing db name and user name in config.json file.
- To get the csv dump run the following command:  
 python3 csv_dump.py --active_timestamp [start_date]  --end_timestamp [end_date]
eg: python3 csv_dump.py --start_timestamp 2019-01-30 --end_timestamp 2019-01-31

- You should see the data dump in moc-reporting_csv_dump folder under the timestamp folder when it was run. 

